### PR TITLE
fix(security): exclude password_hash from admin backup export

### DIFF
--- a/app/api/admin/backup/route.ts
+++ b/app/api/admin/backup/route.ts
@@ -46,7 +46,12 @@ export async function GET(request: NextRequest) {
     for (const table of tables) {
       const tableName = table.name;
       const rows = await query<Record<string, unknown>>(`SELECT * FROM ${tableName}`);
-      backup[tableName] = rows;
+      // Exclude password_hash from users: hashes in a backup file are an offline attack vector
+      if (tableName === 'users') {
+        backup[tableName] = rows.map(({ password_hash: _, ...rest }) => rest);
+      } else {
+        backup[tableName] = rows;
+      }
     }
 
     // Generate filename with timestamp


### PR DESCRIPTION
SELECT * FROM users included password_hash (bcrypt cost 12) in the backup JSON. If the backup file is stored insecurely, hashes become an offline attack vector. Strip the field after fetch using destructuring so all other user fields are still exported.

Fixes: security.md #4