### PR TITLE
fix(security): validate pix3lwikiUrl before injecting into __PIX3L_CO…

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
+import { z } from 'zod';
 import './globals.css';
 import { AppProvider } from '@/components/providers/AppProvider';
 import { ToastContainer } from '@/components/ui/Toast';
@@ -27,9 +28,13 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const pix3lConfig = {
-    pix3lwikiUrl: process.env.PIX3LWIKI_URL || process.env.NEXT_PUBLIC_PIX3LWIKI_URL || 'http://localhost:3001',
-  };
+  const rawWikiUrl = process.env.PIX3LWIKI_URL || process.env.NEXT_PUBLIC_PIX3LWIKI_URL || '';
+  const parsed = z.string().url().safeParse(rawWikiUrl);
+  const pix3lwikiUrl = (parsed.success && parsed.data.startsWith('https://'))
+    ? parsed.data
+    : 'https://wiki.pix3ltools.com';
+
+  const pix3lConfig = { pix3lwikiUrl };
 
   return (
     <html lang="en" className="dark">


### PR DESCRIPTION
…NFIG__

On Docker, PIX3LWIKI_URL could be an internal address (e.g. http://pix3lwiki:3000) that would expose private network topology to unauthenticated clients. Validate with Zod that the URL is well-formed and HTTPS; fall back to the public default if not.

Fixes: security.md #5